### PR TITLE
Remove unused `crate-type` manifest key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ repository = "https://github.com/ddddddeon/a"
 license = "MIT"
 version = "0.1.11"
 edition = "2021"
-crate-type = "bin"
 
 [dependencies]
 bat = "0.22.1"


### PR DESCRIPTION
While building, I got the following warning:

```
warning: unused manifest key: package.crate-type
```

This is because [crate-type](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field) is not valid for the `[package]` section. However, it can be used for `[lib]`, `[bin]` etc.

Since `a` is already defined in `[[bin]]` as a binary, specifying the `crate-type` is unnecessary. So we can simply remove `crate-type` from `Cargo.toml`.
