### PR TITLE
Migrate to chat API

### DIFF
--- a/src/gpt.rs
+++ b/src/gpt.rs
@@ -7,11 +7,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_str, Value};
 use std::error::Error;
 use std::io::Read;
+use std::time::Duration;
 
 const OPENAI_API_URL: &str = "https://api.openai.com/v1/chat/completions";
 const OPENAI_MODEL: &str = "gpt-3.5-turbo";
 const MAX_TOKENS: u32 = 4000;
-const TEMPERATURE: f32 = 0.2;
+const TEMPERATURE: f32 = 0.3;
 
 type BoxResult<T> = Result<T, Box<dyn Error>>;
 
@@ -53,7 +54,7 @@ impl GPTClient {
         }
 
         let system =
-            "You are a system that only generates code. Do not describe or contextualize the code. Do not apply any formatting or syntax highlighting.";
+            "You are a system that only generates code. Do not describe or contextualize the code. Do not apply any formatting or syntax highlighting. Do not wrap the code in a code block.";
 
         let messages = vec![
             Message {
@@ -82,14 +83,14 @@ impl GPTClient {
 
         let body = serde_json::to_string(&p)?;
 
-        let client = Client::new();
+        let client = Client::builder().timeout(Duration::from_secs(60)).build()?;
         let mut res = client.post(&self.url).body(body).headers(headers).send()?;
 
         let mut response_body = String::new();
         res.read_to_string(&mut response_body)?;
         let json_object: Value = from_str(&response_body)?;
         let answer = json_object["choices"][0]["message"]["content"].as_str();
-        util::pretty_print(&response_body, "json");
+
         match answer {
             Some(a) => Ok(String::from(a)),
             None => {


### PR DESCRIPTION
This pull request migrates the API call to the new chat API using the `gpt-3.5-turbo` model instead of `text-davinci-003`. 
