### PR TITLE
Respect the "NO_COLOR" env variable to disable colorized output.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -27,6 +27,10 @@ pub fn pretty_print(str: &str, lang: &str) {
         lang = "txt".to_owned();
     }
 
+    if std::env::var("NO_COLOR").is_ok() {
+        pp.colored_output(false);
+    }
+
     pp.input_from_bytes(str.as_bytes())
         .language(&lang)
         .print()


### PR DESCRIPTION
A small change which checks for the `NO_COLOR` environment variable and if set, will disable colorized output.  Makes the results of `a` more useful when piped or written to a file directly.